### PR TITLE
Add Netgear A6100 Customer ID

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -285,6 +285,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	/*=== Customer ID ===*/
 	{USB_DEVICE(0x7392, 0xA811),.driver_info = RTL8821}, /* Edimax - Edimax */
 	{USB_DEVICE(0x2001, 0x3314),.driver_info = RTL8821}, /* D-Link - Cameo */
+	{USB_DEVICE(0x0846, 0x9052),.driver_info = RTL8821}, /* Netgear - A6100 */
 #endif
 
 #ifdef CONFIG_RTL8192E


### PR DESCRIPTION
Applied the patch found in this post http://forum.ubuntuusers.de/topic/problem-mit-netgear-wlan-mini-adapter-wps-a610/#post-6222752

Compiles correctly and works with an old laptop of mine with kernel 3.11 on Ubuntu 13.10.

Thanks for the driver! :beers: 
