### PR TITLE
Removed ^M from ioctl_cfg80211.c so now it compiles!

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -595,11 +595,11 @@ void rtw_cfg80211_indicate_disconnect(_adapter *padapter)
 		//DBG_8192C("pwdev->sme_state(b)=%d\n", pwdev->sme_state);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,11,0)
-		if(pwdev->sme_state==CFG80211_SME_CONNECTING)^M
-			cfg80211_connect_result(padapter->pnetdev, NULL, NULL, 0, NULL, 0, ^M
-				WLAN_STATUS_UNSPECIFIED_FAILURE, GFP_ATOMIC/*GFP_KERNEL*/);^M
-		else if(pwdev->sme_state==CFG80211_SME_CONNECTED)^M
-			cfg80211_disconnected(padapter->pnetdev, 0, NULL, 0, GFP_ATOMIC);^M
+		if(pwdev->sme_state==CFG80211_SME_CONNECTING)
+			cfg80211_connect_result(padapter->pnetdev, NULL, NULL, 0, NULL, 0, 
+				WLAN_STATUS_UNSPECIFIED_FAILURE, GFP_ATOMIC/*GFP_KERNEL*/);
+		else if(pwdev->sme_state==CFG80211_SME_CONNECTED)
+			cfg80211_disconnected(padapter->pnetdev, 0, NULL, 0, GFP_ATOMIC);
 #else
 		cfg80211_disconnected(padapter->pnetdev, 0, NULL, 0, GFP_ATOMIC);
 #endif


### PR DESCRIPTION
(Something something, windows line endings ***\* something, something)
