### PR TITLE
a parameter was removed from cfg80211_rx_mgmt function; tested on 3.18.3...

### DIFF
--- a/include/ioctl_cfg80211.h
+++ b/include/ioctl_cfg80211.h
@@ -109,9 +109,12 @@ bool rtw_cfg80211_pwr_mgmt(_adapter *adapter);
   #define rtw_cfg80211_rx_mgmt(adapter, freq, sig_dbm, buf, len, gfp) cfg80211_rx_mgmt((adapter)->pnetdev, freq, sig_dbm, buf, len, gfp)
 #elif (LINUX_VERSION_CODE < KERNEL_VERSION(3,12,0))
   #define rtw_cfg80211_rx_mgmt(adapter, freq, sig_dbm, buf, len, gfp) cfg80211_rx_mgmt((adapter)->rtw_wdev, freq, sig_dbm, buf, len, gfp)
-#else
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3,18,0))
   // 3.12 added a flags argument which is just set to zero
   #define rtw_cfg80211_rx_mgmt(adapter, freq, sig_dbm, buf, len, gfp) cfg80211_rx_mgmt((adapter)->rtw_wdev, freq, sig_dbm, buf, len, 0, gfp)
+#else
+  // 3.18 a parameter was removed from cfg80211_rx_mgmt function 
+  #define rtw_cfg80211_rx_mgmt(adapter, freq, sig_dbm, buf, len, gfp) cfg80211_rx_mgmt((adapter)->rtw_wdev, freq, sig_dbm, buf, len, 0)
 #endif
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0))  && !defined(COMPAT_KERNEL_RELEASE)


### PR DESCRIPTION
Hello, 
I tried to compile the driver on Fedora 21 and got a compilation error.
The error has been fixed by removing the latest parameter from the cfg80211_rx_mgmt call


P.S. This pull request is sent with TP-Link Archer T4U that seems is reliable connected to my wireless router with the patched kernel module. However  I'm not 100% sure that the fix is correct due lack of experience in kernel development. 

Thanks,
Vitaly