### PR TITLE
Fix for Oops encountered using Edimax AC600 adapter. Logically this c…

### DIFF
--- a/hal/rtl8812a/rtl8812a_phycfg.c
+++ b/hal/rtl8812a/rtl8812a_phycfg.c
@@ -921,7 +921,10 @@ PHY_ConvertPowerLimitToPowerIndex(
 							// obtain the base dBm values in 5G band
 							// OFDM => 54M, HT 1T => MCS7, HT 2T => MCS15, 
 							// VHT => 1SSMCS7, VHT 2T => 2SSMCS7
-							if ( rateSection == 1 ) { //OFDM
+							if ( rateSection == 0 ) { //CCK - Unused by 5g, but if baseIndex5G is undefined, causes crash
+								baseIndex5G = phy_getPowerByRateBaseIndex( BAND_ON_5G, MGN_11M );
+							}
+							else if ( rateSection == 1 ) { //OFDM
 								baseIndex5G = phy_getPowerByRateBaseIndex( BAND_ON_5G, MGN_54M );
 							}
 							else if ( rateSection == 2 ) { //HT 1T
@@ -1043,7 +1046,10 @@ PHY_ConvertPowerLimitToPowerIndex(
 							// obtain the base dBm values in 5G band
 							// OFDM => 54M, HT 1T => MCS7, HT 2T => MCS15, 
 							// VHT => 1SSMCS7, VHT 2T => 2SSMCS7
-							if ( rateSection == 1 ) { //OFDM
+							if ( rateSection == 0 ) { //CCK - Unused by 5g, but if baseIndex5G is undefined, causes crash
+								baseIndex5G = phy_getPowerByRateBaseIndex( BAND_ON_5G, MGN_11M );
+							}
+							else if ( rateSection == 1 ) { //OFDM
 								baseIndex5G = phy_getPowerByRateBaseIndex( BAND_ON_5G, MGN_54M );
 							}
 							else if ( rateSection == 2 ) { //HT 1T


### PR DESCRIPTION
…an occur on any system with any 5G interface using this driver.

Oops encountered on Ubuntu 14.04 LTS with Raspberry Pi 2
Example kernel log of Oops:
Jan  1 00:00:10 rpi2 kernel: [    7.069349] Unable to handle kernel paging request at virtual address 31fab237
Jan  1 00:00:10 rpi2 kernel: [    7.078173] pgd = b2b2c000
Jan  1 00:00:10 rpi2 kernel: [    7.087284] [31fab237] *pgd=00000000
Jan  1 00:00:10 rpi2 kernel: [    7.096431] Internal error: Oops: 5 [#1] PREEMPT SMP ARM
Jan  1 00:00:10 rpi2 kernel: [    7.105658] Modules linked in: cfg80211 rfkill 8812au(O) 8192cu cp210x usbserial snd_soc_bcm2708_i2s regmap_mmio snd_soc_core bcm2708_rng spi_bcm2708 snd_compress
i2c_bcm2708 snd_bcm2835 snd_pcm_dmaengine snd_pcm snd_timer snd fuse
Jan  1 00:00:10 rpi2 kernel: [    7.135771] CPU: 0 PID: 508 Comm: wpa_supplicant Tainted: G           O   3.18.0-23-rpi2 #24-Ubuntu
Jan  1 00:00:10 rpi2 kernel: [    7.157466] task: b2adb840 ti: b1832000 task.ti: b1832000
Jan  1 00:00:10 rpi2 kernel: [    7.168907] PC is at PHY_ConvertPowerLimitToPowerIndex+0x540/0x9e8 [8812au]
Jan  1 00:00:10 rpi2 kernel: [    7.180810] LR is at PHY_ConvertPowerLimitToPowerIndex+0x528/0x9e8 [8812au]
Jan  1 00:00:10 rpi2 kernel: [    7.192390] pc : [<7f21193c>]    lr : [<7f211924>]    psr: 60000013
Jan  1 00:00:10 rpi2 kernel: [    7.192390] sp : b1833d10  ip : 80913bf0  fp : 0000345c
Jan  1 00:00:10 rpi2 kernel: [    7.215709] r10: 00000000  r9 : 00000000  r8 : b2d7a872
Jan  1 00:00:10 rpi2 kernel: [    7.227351] r7 : b2d78000  r6 : b2d7a872  r5 : 00000000  r4 : 0000003f
Jan  1 00:00:10 rpi2 kernel: [    7.239176] r3 : 31fab235  r2 : 00000001  r1 : 7f230470  r0 : 0000001b
Jan  1 00:00:10 rpi2 kernel: [    7.251116] Flags: nZCv  IRQs on  FIQs on  Mode SVC_32  ISA ARM  Segment user
Jan  1 00:00:10 rpi2 kernel: [    7.263383] Control: 10c5387d  Table: 32b2c06a  DAC: 00000015
Jan  1 00:00:10 rpi2 kernel: [    7.275905] Process wpa_supplicant (pid: 508, stack limit = 0xb1832238)
...
Jan  1 00:00:10 rpi2 kernel: [    8.107493] [<7f21193c>] (PHY_ConvertPowerLimitToPowerIndex [8812au]) from [<7f212004>] (PHY_BBConfig8812+0x220/0x378 [8812au])
Jan  1 00:00:10 rpi2 kernel: [    8.144381] [<7f212004>] (PHY_BBConfig8812 [8812au]) from [<7f21b374>] (rtl8812au_hal_init+0xcf8/0x101c [8812au])
Jan  1 00:00:10 rpi2 kernel: [    8.181404] [<7f21b374>] (rtl8812au_hal_init [8812au]) from [<7f202a60>] (rtw_hal_init+0x20/0x9c [8812au])
Jan  1 00:00:10 rpi2 kernel: [    8.218490] [<7f202a60>] (rtw_hal_init [8812au]) from [<7f1f051c>] (_netdev_open+0x74/0x2fc [8812au])
Jan  1 00:00:10 rpi2 kernel: [    8.255699] [<7f1f051c>] (_netdev_open [8812au]) from [<7f1f07c4>] (netdev_open+0x20/0x38 [8812au])
Jan  1 00:00:10 rpi2 kernel: [    8.292954] [<7f1f07c4>] (netdev_open [8812au]) from [<804e93ac>] (__dev_open+0xb8/0x130)
Jan  1 00:00:10 rpi2 kernel: [    8.330207] [<804e93ac>] (__dev_open) from [<804e9648>] (__dev_change_flags+0x94/0x158)
Jan  1 00:00:10 rpi2 kernel: [    8.367540] [<804e9648>] (__dev_change_flags) from [<804e9724>] (dev_change_flags+0x18/0x48)
Jan  1 00:00:10 rpi2 kernel: [    8.405013] [<804e9724>] (dev_change_flags) from [<8054f7b4>] (devinet_ioctl+0x6ac/0x784)
Jan  1 00:00:10 rpi2 kernel: [    8.442641] [<8054f7b4>] (devinet_ioctl) from [<804cd3b0>] (sock_ioctl+0x1c8/0x294)
Jan  1 00:00:10 rpi2 kernel: [    8.480357] [<804cd3b0>] (sock_ioctl) from [<8015ad10>] (do_vfs_ioctl+0x3f0/0x5b4)
Jan  1 00:00:10 rpi2 kernel: [    8.518159] [<8015ad10>] (do_vfs_ioctl) from [<8015af40>] (SyS_ioctl+0x6c/0x7c)
Jan  1 00:00:10 rpi2 kernel: [    8.537149] [<8015af40>] (SyS_ioctl) from [<8000ef20>] (ret_fast_syscall+0x0/0x48)
Jan  1 00:00:10 rpi2 kernel: [    8.574745] Code: 059d103c 00873001 02833db7 02833005 (05d33002)
Jan  1 00:00:10 rpi2 kernel: [    8.594684] ---[ end trace 6b00f140650346ba ]---