### PR TITLE
Fix debug message if conditions. These were using if (BAND_ON_5G) typ…

### DIFF
--- a/hal/rtl8812a/rtl8812a_phycfg.c
+++ b/hal/rtl8812a/rtl8812a_phycfg.c
@@ -1266,9 +1266,9 @@ PHY_GetPowerLimitValue(
 			break;
 	}
 
-	if ( BAND_ON_2_4G  && rateSection > 3 )
+	if ( Band == BAND_ON_2_4G  && rateSection > 3 )
 			DBG_871X("Wrong rate 0x%x: No VHT in 2.4G Band\n", DataRate );
-	if ( BAND_ON_5G  && rateSection == 0 )
+	if ( Band == BAND_ON_5G  && rateSection == 0 )
 			DBG_871X("Wrong rate 0x%x: No CCK in 5G Band\n", DataRate );
 
 	// workaround for wrong index combination to obtain tx power limit, 


### PR DESCRIPTION
…e logic, but these values are values from an enum and need to be compared to something for proper testing.