### PR TITLE
add OUTLINK vendor id

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ sudo dkms install -m rtl8812AU_8821AU_linux -v 1.0
 ```
 
 ## To compile on the raspberry pi using raspian
-### You first need kernel headers (and the corresponding kernel binary) to build your module. 
+#### You first need kernel headers (and the corresponding kernel binary) to build your module. 
 ```
 sudo apt-get install linux-image-rpi-rpfv linux-headers-rpi-rpfv dkms build-essential bc
 ```
-### Then, tell raspbian to boot your newly installed kernel.  Append this at end of /boot/config.txt and reboot your Pi:
+#### Then, tell raspbian to boot your newly installed kernel.  Append this at end of /boot/config.txt and reboot your Pi:
 ```
 kernel=vmlinuz-3.10-3-rpi
 initramfs initrd.img-3.10-3-rpi followkernel
 ```
-### Cd to the directory where your source is and compile
+#### Cd to the directory where your source is and compile
 ```
 cd /usr/src/rtl8812AU_8821AU_linux
 sudo make clean 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ rtl8812AU_8821AU_linux
 
 rtl8812AU_8821AU linux kernel driver for AC1200 (801.11ac) Wireless Dual-Band USB Adapter
 
-##Autocompiling with DKMS
+## Autocompiling with DKMS
 
 ```
 sudo cp -R . /usr/src/rtl8812AU_8821AU_linux-1.0
@@ -11,4 +11,24 @@ sudo dkms add -m rtl8812AU_8821AU_linux -v 1.0
 sudo dkms build -m rtl8812AU_8821AU_linux -v 1.0
 sudo dkms install -m rtl8812AU_8821AU_linux -v 1.0
 ```
+
+## To compile on the raspberry pi using raspian
+### You first need kernel headers (and the corresponding kernel binary) to build your module. 
+```
+sudo apt-get install linux-image-rpi-rpfv linux-headers-rpi-rpfv dkms build-essential bc
+```
+### Then, tell raspbian to boot your newly installed kernel.  Append this at end of /boot/config.txt and reboot your Pi:
+```
+kernel=vmlinuz-3.10-3-rpi
+initramfs initrd.img-3.10-3-rpi followkernel
+```
+### Cd to the directory where your source is and compile
+```
+cd /usr/src/rtl8812AU_8821AU_linux
+sudo make clean 
+sudo make 
+sudo make install
+sudo modprobe -a 8812au
+```
+
 

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -289,6 +289,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
         {USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0x0820,0xff,0xff,0xff),.driver_info = RTL8821}, /* 8821AU */
 	/*=== Customer ID ===*/
 	{USB_DEVICE(0x7392, 0xA811),.driver_info = RTL8821}, /* Edimax - Edimax */
+	{USB_DEVICE(0x0BDA, 0xA811),.driver_info = RTL8821}, /* OUTLINK - Edimax */ 
 	{USB_DEVICE(0x7392, 0xA812),.driver_info = RTL8821}, /* Edimax - Edimax */
 	{USB_DEVICE(0x2001, 0x3314),.driver_info = RTL8821}, /* D-Link - Cameo */
 	{USB_DEVICE(0x0846, 0x9052),.driver_info = RTL8821}, /* Netgear - A6100 */


### PR DESCRIPTION
This adds OUTLINK vendor ID so that that driver works on the inexpensive devices.