### PR TITLE
remove warnings and add initialization for struct

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -2254,7 +2254,7 @@ static int rtw_cfg80211_set_key_mgt(struct security_priv *psecuritypriv, u32 key
 	return 0;
 }
 
-static int rtw_cfg80211_set_wpa_ie(_adapter *padapter, u8 *pie, size_t ielen)
+static int rtw_cfg80211_set_wpa_ie(_adapter *padapter, const u8 *pie, size_t ielen)
 {
 	u8 *buf=NULL, *pos=NULL;
 	u32 left;
@@ -3031,7 +3031,12 @@ void rtw_cfg80211_indicate_sta_assoc(_adapter *padapter, u8 *pmgmt_frame, uint f
 			ie_offset = _ASOCREQ_IE_OFFSET_;
 		else // WIFI_REASSOCREQ
 			ie_offset = _REASOCREQ_IE_OFFSET_;
-
+		
+		// the next 2 lines are taken from another rtl driver
+		// in the other driver the BIT(17) was a #define 
+		sinfo.filled = 0;
+		sinfo.filled = BIT(17);
+		
 		sinfo.assoc_req_ies = pmgmt_frame + WLAN_HDR_A3_LEN + ie_offset;
 		sinfo.assoc_req_ies_len = frame_len - WLAN_HDR_A3_LEN - ie_offset;
 		cfg80211_new_sta(ndev, GetAddr2Ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);


### PR DESCRIPTION
This change seems to fix the weird lags I was seeing in the driver.  I have tested on both my edimax ac1200 and my other wifi adapter which uses a similar chip to the edimax 600.  

I have not seen any weird pauses like I used to see.  Some other people to test this would be helpful.