### PR TITLE
Fix dkms build when the target kernel is not currently running.

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,6 +1,6 @@
 PACKAGE_NAME=8812au
 PACKAGE_VERSION=1.0
-MAKE[0]="'make'"
+MAKE[0]="'make' KVER=${kernelver}"
 BUILT_MODULE_NAME[0]=8812au
 BUILT_MODULE_LOCATION[0]="./"
 DEST_MODULE_LOCATION[0]="/kernel/updates/dkms"


### PR DESCRIPTION
Previously when dkms is triggered by e.g. apt-get to build a 8812au for
a non-running kernel, Makefile incorrectly uses the currently running
kernel version via `uname -r`. This causes the "8812au: disagrees about
version of symbol module_layout" error.

This is fixed by providing the correct kernel version provided by dkms
in the kernelver env var.