### PR TITLE
Added detection for TP-Link Archer T4U

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 rtl8812AU_8821AU linux kernel driver for AC1200 (801.11ac) Wireless Dual-Band USB Adapter
 
+## Compiling on Ubuntu 16.04
+
+```cd``` into folder.
+
+```sh
+# sudo make
+# sudo make install
+```
+
 ## Compiling with DKMS
 
 ```sh

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -256,6 +256,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	{USB_DEVICE(USB_VENDER_ID_REALTEK, 0x881B),.driver_info = RTL8812},/* Default ID */
 	{USB_DEVICE(USB_VENDER_ID_REALTEK, 0x881C),.driver_info = RTL8812},/* Default ID */
 	/*=== Customer ID ===*/
+	{USB_DEVICE(0x2357, 0x0101),.driver_info = RTL8812}, /* TP-Link - T4U */
 	{USB_DEVICE(0x050D, 0x1106),.driver_info = RTL8812}, /* Belkin - sercomm */
 	{USB_DEVICE(0x050D, 0x1109),.driver_info = RTL8812}, /* Belkin F9L1109 - SerComm */
 	{USB_DEVICE(0x2001, 0x330E),.driver_info = RTL8812}, /* D-Link - ALPHA */


### PR DESCRIPTION
Added detection for TP-Link Archer T4U, as well as simple Ubuntu instructions. The instructions aren't necessary, but support for the T4U is.