### PR TITLE
Added auto install bash script (ubuntu/debian)

### DIFF
--- a/contrib/auto-install.sh
+++ b/contrib/auto-install.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+##
+## Automated setup for Netgear A6100 AC600 usb wifi adapter drivers
+## Designed for Ubuntu Xenial 16.04 LTS (and Debian distros generally)
+##
+## This is a simple bash script to automate the installation of the latest rtl8812AU linux drivers for 
+## the NETGEAR A6100 AC600 usb wifi dongle from https://github.com/abperiasamy/rtl8812AU_8821AU_linux .
+## This script was created specifically for Ubuntu Xenial 16.04 LTS, but should work as is, or with
+## minor modifications, on any Debian based linux distribution.
+##
+## This script: 
+## 	(1) installs git to pull the repository and gcc (and associated build tools)
+## 	(2) compiles the driver binary and installs it to the system
+## 	(3) creates a udev rule to rename the interface to "wlan0" (optional)
+##	(4) loads the driver and adds a modprobe rule to do this at boot
+##
+
+## Install Dependencies
+apt update
+apt install -y git build-essential make autoconf libtool gcc gettext
+
+## Clone latest github repository
+cd /var/lib/git
+git clone https://github.com/abperiasamy/rtl8812AU_8821AU_linux.git
+
+## Compile and install driver binary
+cd rtl8812AU_8821AU_linux
+make
+make install
+
+## Make udev rule (you can omit this line to have the system automatically name the device, or change NAME="wlan0" to a diffrent device name)
+echo 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="rtl8812au", ATTR{type}=="1", NAME="wlan0"' >> /lib/udev/rules.d/70-persistent-network.rules
+
+## Load driver module
+modprobe 8812au
+
+## Add module at boot (file may be /etc/modules on other distribution)
+echo -e '# Netgear A600 usb wifi dongle\n8812au' > /etc/modules-load.d/8812au.conf


### PR DESCRIPTION
I wrote this bash script to automate the process of compiling and install this driver on Ubuntu Xenial, but the script is usable as is (or with minor tweaks) on pretty much any Debian based distro. I would be able to write a version for red hat (or for specific distros) if wanted, but wanted to see if this would be useful before bothering.

I thought it might be a useful, especially for novice linux users, either as a no-brain install method that could be added to the readme (i.e. `./auto-install.sh`) or as a guide to demonstrate the steps for installing the driver. I added some comments to explain what each group of commands does.

I realize this might be just be clutter for the project, but I thought I would push it and let you decide if it would be useful or not. Thanks again for all the hard work on this driver, it is much appreciated!