### PR TITLE
Re-add module parameter for status LED.

### DIFF
--- a/hal/led/hal_usb_led.c
+++ b/hal/led/hal_usb_led.c
@@ -21,6 +21,22 @@
 #include <drv_types.h>
 #include <hal_data.h>
 
+void
+rtw_led_control(
+    _adapter *adapter,
+    LED_CTL_MODE LedAction
+    )
+{
+    if (adapter->registrypriv.led_enable)
+    {
+        do
+        {
+            (adapter)->ledpriv.LedControlHandler((adapter), (LedAction));
+        }
+        while(0);
+    }
+}
+
 //
 //	Description:
 //		Implementation of LED blinking behavior.

--- a/include/drv_types.h
+++ b/include/drv_types.h
@@ -333,6 +333,10 @@ struct registry_priv {
 	u8 adaptivity_dml;
 	u8 boffefusemask;
 	BOOLEAN bFileMaskEfuse;
+
+#ifdef CONFIG_SW_LED
+	u8 led_enable;
+#endif
 };
 
 

--- a/include/hal_com_led.h
+++ b/include/hal_com_led.h
@@ -353,11 +353,7 @@ struct led_priv {
 };
 
 #ifdef CONFIG_SW_LED
-#define rtw_led_control(adapter, LedAction) \
-	do { \
-		if((adapter)->ledpriv.LedControlHandler) \
-			(adapter)->ledpriv.LedControlHandler((adapter), (LedAction)); \
-	} while(0)
+void rtw_led_control(_adapter *adapter, LED_CTL_MODE LedAction);
 #else //CONFIG_SW_LED
 #define rtw_led_control(adapter, LedAction)
 #endif //CONFIG_SW_LED

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -328,6 +328,12 @@ uint rtw_notch_filter = RTW_NOTCH_FILTER;
 module_param(rtw_notch_filter, uint, 0644);
 MODULE_PARM_DESC(rtw_notch_filter, "0:Disable, 1:Enable, 2:Enable only for P2P");
 
+#ifdef CONFIG_SW_LED
+int rtw_led_enable = 1;
+module_param(rtw_led_enable, int, 0644);
+MODULE_PARM_DESC(rtw_led_enable,"Enable status LED");
+#endif //CONFIG_SW_LED
+
 uint rtw_hiq_filter = CONFIG_RTW_HIQ_FILTER;
 module_param(rtw_hiq_filter, uint, 0644);
 MODULE_PARM_DESC(rtw_hiq_filter, "0:allow all, 1:allow special, 2:deny all");
@@ -577,6 +583,10 @@ uint loadparam( _adapter *padapter,  _nic_hdl	pnetdev)
 #ifdef CONFIG_MULTI_VIR_IFACES
 	registry_par->ext_iface_num = (u8)rtw_ext_iface_num;
 #endif //CONFIG_MULTI_VIR_IFACES
+
+#ifdef CONFIG_SW_LED
+       registry_par->led_enable = (u8)rtw_led_enable;
+#endif //CONFIG_SW_LED
 
 	registry_par->RegEnableTxPowerLimit = (u8)rtw_tx_pwr_lmt_enable;
 	registry_par->RegEnableTxPowerByRate = (u8)rtw_tx_pwr_by_rate;


### PR DESCRIPTION
This feature was lost when "merge new version v4.3.14" was applied.

Original commit: ea61cdf0fa85d5341a6bc1d3ae531c0190726827