### PR TITLE
Update usb_intf.c to support new TP-Link device (010d)

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -297,6 +297,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x2001, 0x3316),.driver_info = RTL8812}, /* D-Link - Cameo */
 	{USB_DEVICE(0x20F4, 0x805B),.driver_info = RTL8812}, /* TRENDnet - Cameo */
 	{USB_DEVICE(0x2357, 0x0101),.driver_info = RTL8812}, /* TP-Link - Archer T4U */
+	{USB_DEVICE(0x2357, 0x010d),.driver_info = RTL8812}, /* TP-Link - Archer T4U AC1300 */
 	{USB_DEVICE(0x2357, 0x0103),.driver_info = RTL8812}, /* TP-Link - T4UH */
 	{USB_DEVICE(0x148F, 0x9097),.driver_info = RTL8812}, /* Amped Wireless ACA1 */
 #endif


### PR DESCRIPTION
Greetings, I'd like to contribute changes to enable support for the new TP-Link T4U USB 3 WiFi router stick. I bought one from a local supplier in South Africa (TP LINK T4U AC1300 WLSS D-BND USB ADAPT).

To get it to work I had to modify the usb_intf.c file, around line 300 to add {USB_DEVICE(0x2357,0x010d),driver_info=RTL8812} under the similar line for product ID 0101.