### PR TITLE
Make it easier to enable debug logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,10 @@ CONFIG_PLATFORM_TI_DM365 = n
 CONFIG_PLATFORM_MOZART = n
 CONFIG_PLATFORM_RTK119X = n
 CONFIG_PLATFORM_NOVATEK_NT72668 = n
+########################## DEBUG ##############################
+CONFIG_DEBUG = n
+CONFIG_DEBUG_CFG80211 = n
+CONFIG_DEBUG_RTL871X = n
 ###############################################################
 
 CONFIG_DRVEXT_MODULE = n
@@ -1505,6 +1509,16 @@ endif
 
 ifneq ($(KERNELRELEASE),)
 KERNELRELEASE := $(shell uname -r)
+endif
+
+ifeq ($(CONFIG_DEBUG), y)
+EXTRA_CFLAGS += -DCONFIG_DEBUG
+endif
+ifeq ($(DCONFIG_DEBUG_CFG80211), y)
+EXTRA_CFLAGS += -DCONFIG_DEBUG_CFG80211
+endif
+ifeq ($(DCONFIG_DEBUG_RTL871X), y)
+EXTRA_CFLAGS += -DCONFIG_DEBUG_RTL871X
 endif
 
 rtk_core :=	core/rtw_cmd.o \


### PR DESCRIPTION
Add CONFIG_DEBUG, CONFIG_DEBUG_CFG80211 and CONFIG_DEBUG_RTL871X options
to the Makefile.