### PR TITLE
rtw_mlme_ext: fix unhandled page fault

### DIFF
--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -12125,7 +12125,7 @@ u8 join_cmd_hdl(_adapter *padapter, u8 *pbuf)
 		}
 
 		i += (pIE->Length + 2);
-	} while (pnetwork->IELength - i > 0);
+	} while (pnetwork->IELength > i);
 #if 0
 	if (padapter->registrypriv.wifi_spec) {
 		// for WiFi test, follow WMM test plan spec


### PR DESCRIPTION
A subtraction of two unsigned numbers was compared to zero for a loop
terminating condition. If the numbers are not equal, the loop will continue
until the pointers go beyond the mapped memory region and cause an unhandled
page fault.