### PR TITLE
Add the other TP-Link T4UHP USB PID to the list

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -301,6 +301,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x2357, 0x010E),.driver_info = RTL8812}, /* TP-Link - Archer T4UH AC1300 */
 	{USB_DEVICE(0x2357, 0x0103),.driver_info = RTL8812}, /* TP-Link - T4UH */
 	{USB_DEVICE(0x2357, 0x010F),.driver_info = RTL8812}, /* TP-Link - T4UHP */
+	{USB_DEVICE(0x2357, 0x0122),.driver_info = RTL8812}, /* TP-Link - T4UHP (other) */
 	{USB_DEVICE(0x148F, 0x9097),.driver_info = RTL8812}, /* Amped Wireless ACA1 */
 #endif
 


### PR DESCRIPTION
Some TP-Link Archer T4UHP are shipped with USB PID value
of 0x0122 instead of the normal 0x010F.