### PR TITLE
add missing net/ip6_checksum.h include

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -47,6 +47,7 @@
 #ifdef __KERNEL__
 #include <linux/ipv6.h>
 #include <linux/icmpv6.h>
+#include <net/ip6_checksum.h>
 #include <net/ndisc.h>
 #include <net/checksum.h>
 #endif


### PR DESCRIPTION
this fixes build on arm64 (Armbian, kernel 4.14.14-sunxi64 on NanoPI NEO2), BTW I had to set ARCH to arm64 otherwise it chooses aarch64 instead (and fails due to missing arch/aarch64/Makefile in kernel's headers)

without this patch, I'm getting:

$ make ARCH=arm64                                                                                                                                                                                                                     
make ARCH=arm64 CROSS_COMPILE= -C /lib/modules/4.14.14-sunxi64/build M=/home/piotr/firmware/rtl8812AU_8821AU_linux  modules                                                                                                                                                                          
make[1]: Entering directory '/usr/src/linux-headers-4.14.14-sunxi64'                                                                                                                                                                                                                                 
  CC [M]  /home/piotr/firmware/rtl8812AU_8821AU_linux/core/rtw_br_ext.o                                                                                                                                                                                                                              
/home/piotr/firmware/rtl8812AU_8821AU_linux/core/rtw_br_ext.c: In function ‘nat25_db_handle’:                                                                                                                                                                                                        
/home/piotr/firmware/rtl8812AU_8821AU_linux/core/rtw_br_ext.c:1346:26: error: implicit declaration of function ‘csum_ipv6_magic’ [-Werror=implicit-function-declaration]                                                                                                                             
       hdr->icmp6_cksum = csum_ipv6_magic(&iph->saddr, &iph->daddr,
                          ^~~~~~~~~~~~~~~
cc1: all warnings being treated as errors                                                                                                                                                                                                                                                            
scripts/Makefile.build:314: recipe for target '/home/piotr/firmware/rtl8812AU_8821AU_linux/core/rtw_br_ext.o' failed                                                                                                                                                                                 
make[2]: *** [/home/piotr/firmware/rtl8812AU_8821AU_linux/core/rtw_br_ext.o] Error 1
Makefile:1507: recipe for target '_module_/home/piotr/firmware/rtl8812AU_8821AU_linux' failed
make[1]: *** [_module_/home/piotr/firmware/rtl8812AU_8821AU_linux] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-4.14.14-sunxi64'
Makefile:1584: recipe for target 'modules' failed
make: *** [modules] Error 2