### PR TITLE
Fixing build error from unused variable warnings

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4052,7 +4052,7 @@ exit:
 	return ret;
 }
 
-static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev,
+/*static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,0))
 		struct station_del_parameters *params)
 {
@@ -4145,7 +4145,7 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 	return ret;
 
 }
-
+*/
 static int	cfg80211_rtw_change_station(struct wiphy *wiphy, struct net_device *ndev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3,16,0))
                                         u8 *mac,
@@ -5998,7 +5998,7 @@ static struct cfg80211_ops rtw_cfg80211_ops = {
 #endif
 
 	.add_station = cfg80211_rtw_add_station,
-	.del_station = cfg80211_rtw_del_station,
+	//.del_station = cfg80211_rtw_del_station,
 	.change_station = cfg80211_rtw_change_station,
 	.dump_station = cfg80211_rtw_dump_station,
 	.change_bss = cfg80211_rtw_change_bss,


### PR DESCRIPTION
This commit fixes the issue #235. A variable and a function were commented.

Successfully tested on:

Distributor ID: Debian
Description: Debian GNU/Linux 8.10 (jessie)
Release: 8.10
Codename: Jessie
Kernel: 3.19.0 x86_64 (custom)