### PR TITLE
Revert "Fixing Build error from unused variable warnings (#240)"

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4052,7 +4052,7 @@ exit:
 	return ret;
 }
 
-/*static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev,
+static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,0))
 		struct station_del_parameters *params)
 {
@@ -4145,7 +4145,7 @@ exit:
 	return ret;
 
 }
-*/
+
 static int	cfg80211_rtw_change_station(struct wiphy *wiphy, struct net_device *ndev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3,16,0))
                                         u8 *mac,
@@ -5998,7 +5998,7 @@ static struct cfg80211_ops rtw_cfg80211_ops = {
 #endif
 
 	.add_station = cfg80211_rtw_add_station,
-	//.del_station = cfg80211_rtw_del_station,
+	.del_station = cfg80211_rtw_del_station,
 	.change_station = cfg80211_rtw_change_station,
 	.dump_station = cfg80211_rtw_dump_station,
 	.change_bss = cfg80211_rtw_change_bss,


### PR DESCRIPTION
This reverts commit 3059b62c983d062d16fe1e43b576e27eafe2f98c.

Reinstate del_station to satisfy kernel validation.

See https://github.com/abperiasamy/rtl8812AU_8821AU_linux/issues/235#issuecomment-368825840