### PR TITLE
Add USB Device T4U AC1300 with 2357:0115

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -299,6 +299,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x20F4, 0x805B),.driver_info = RTL8812}, /* TRENDnet - Cameo */
 	{USB_DEVICE(0x2357, 0x0101),.driver_info = RTL8812}, /* TP-Link - Archer T4U */
 	{USB_DEVICE(0x2357, 0x010D),.driver_info = RTL8812}, /* TP-Link - Archer T4U AC1300 */
+        {USB_DEVICE(0x2357, 0x0115),.driver_info = RTL8812}, /* TP-Link - Archer T4U AC1300 */
 	{USB_DEVICE(0x2357, 0x010E),.driver_info = RTL8812}, /* TP-Link - Archer T4UH AC1300 */
 	{USB_DEVICE(0x2357, 0x0103),.driver_info = RTL8812}, /* TP-Link - T4UH */
 	{USB_DEVICE(0x2357, 0x010F),.driver_info = RTL8812}, /* TP-Link - T4UHP */


### PR DESCRIPTION
I bought a T4U AC1300 and do the steps it doesn't work.

when I look at `lsusb` it gave out 
`Bus 003 Device 002: ID 2357:0115`

I add that line an it now works.

Although I haven't test the network speed capability yet. 
The indicator light is not blinking but I can use the wifi to connect to the wifi.