### PR TITLE
Add explicit memset call to avoid potentially corrupt data.

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3330,6 +3330,7 @@ void rtw_cfg80211_indicate_sta_assoc(_adapter *padapter, u8 *pmgmt_frame, uint f
 #if defined(RTW_USE_CFG80211_STA_EVENT) || defined(COMPAT_KERNEL_RELEASE)
 	{
 		struct station_info sinfo;
+		_rtw_memset(&sinfo, 0, sizeof(struct station_info));
 		u8 ie_offset;
 		if (GetFrameSubType(pmgmt_frame) == WIFI_ASSOCREQ)
 			ie_offset = _ASOCREQ_IE_OFFSET_;


### PR DESCRIPTION
In kernel 4.19, I saw a kernel crash where kfree was trying to free some garbage pointer. This occurred because this structure wasn't explicitly initialized to 0.