### PR TITLE
README: add RPi kernel headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This code is base on version 4.3.14 from https://github.com/diederikdehaas/rtl88
 Install kernel headers and other dependencies.
 
 ```sh
-# sudo apt-get install linux-image-rpi-rpfv linux-headers-rpi-rpfv dkms build-essential bc
+# sudo apt-get install linux-image-rpi-rpfv linux-headers-rpi-rpfv raspberrypi-kernel-headers dkms build-essential bc
 ```
 
 Append following at the end of your ``/boot/config.txt``, reboot your Pi


### PR DESCRIPTION
This was required for me with latest Raspbian stretch.

Without these headers installed, the `make` output was:
```
make ARCH=arm CROSS_COMPILE= -C /lib/modules/4.14.98-v7+/build M=/home/pi/src/rtl8812AU_8821AU_linux  modules
make[1]: *** /lib/modules/4.14.98-v7+/build: No such file or directory.  Stop.
Makefile:1608: recipe for target 'modules' failed
make: *** [modules] Error 2
```