### PR TITLE
Allow building on 5.0

### DIFF
--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -600,7 +600,11 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		goto exit;
 	}
 
+	#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)) {
+	#else
+	if (!access_ok(VERIFY_READ, priv_cmd.buf, priv_cmd.total_len)) {
+	#endif
 		DBG_871X("%s: failed to access memory\n", __FUNCTION__);
 		ret = -EFAULT;
 		goto exit;

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -600,7 +600,7 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		goto exit;
 	}
 
-	if (!access_ok(VERIFY_READ, priv_cmd.buf, priv_cmd.total_len)) {
+	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)) {
 		DBG_871X("%s: failed to access memory\n", __FUNCTION__);
 		ret = -EFAULT;
 		goto exit;


### PR DESCRIPTION
Linux Kernel 5.0 removed the TYPE argument for access_ok, which causes the build to fail.

This fixes it by removing the argument, while keeping it in if using a previous kernel.