### PR TITLE
Fix get_ds() version mismatch compilation error on kernel v5.1.x and above

### DIFF
--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -32,6 +32,10 @@ atomic_t _malloc_size = ATOMIC_INIT(0);
 #endif
 #endif /* DBG_MEMORY_LEAK */
 
+/* This is to fix get_ds() type mismatch on kernels above 5.1.x */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
+	#define get_ds() KERNEL_DS
+#endif
 
 #if defined(PLATFORM_LINUX)
 /*


### PR DESCRIPTION
Replaces get_ds() with KERNEL_DS when compiling on kernels 5.1.x and above. KERNEL_DS is a replacement for get_ds() (Which is legacy).