### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ CONFIG_PLATFORM_ARM_RPI = y
 # sudo modprobe -a rtl8812au
 ```
 
-### Compiling for Ubuntu (16.04)
+### Compiling for Ubuntu (16.04) and Debian (9)
 
 Download archive into temp directory
 
@@ -64,6 +64,11 @@ Unzip
 ```sh
 # unzip master.zip
 # cd rtl8812AU_8821AU_linux-master
+```
+Install kernel headers 
+
+```sh
+# sudo apt install linux-headers-$(uname -r)
 ```
 
 Compile and install from source


### PR DESCRIPTION
Kernel modules are required for compiling. Without these headers installed, the make output was:

```
# make
make ARCH=i386 CROSS_COMPILE= -C /lib/modules/4.9.0-9-686-pae/build M=/tmp/rtl8812AU_8821AU_linux-master  modules
make[1]: *** /lib/modules/4.9.0-9-686-pae/build: No such file or directory.  Stop.
Makefile:1608: recipe for target 'modules' failed
make: *** [modules] Error 2
```