### PR TITLE
Add support for NVidia Jetson Nano

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,11 @@ CONFIG_AP_WOWLAN = n
 ######### Notify SDIO Host Keep Power During Syspend ##########
 CONFIG_RTW_SDIO_PM_KEEP_POWER = y
 ###################### Platform Related #######################
-CONFIG_PLATFORM_I386_PC = y
+# Jeston Nano Headers
+# /usr/src/linux-headers-4.9.140-tegra-ubuntu18.04_aarch64/kernel-4.9
+CONFIG_PLATFORM_I386_PC = n
 CONFIG_PLATFORM_ARM_RPI = n
+CONFIG_PLATFORM_ARM_JET_NANO = y
 CONFIG_PLATFORM_ANDROID_X86 = n
 CONFIG_PLATFORM_ANDROID_INTEL_X86 = n
 CONFIG_PLATFORM_JB_X86 = n
@@ -907,6 +910,17 @@ KVER ?= $(shell uname -r)
 KSRC := /lib/modules/$(KVER)/build
 MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 INSTALL_PREFIX :=
+endif
+
+# NVidia Jetson Nano
+ifeq ($(CONFIG_PLATFORM_ARM_JET_NANO), y)
+EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+ARCH := arm64
+KVER ?= $(shell uname -r)
+KSRC := /usr/src/linux-headers-$(KVER)-ubuntu18.04_aarch64/kernel-4.9
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/realtek/rtl8812au/
 endif
 
 ifeq ($(CONFIG_PLATFORM_ACTIONS_ATM702X), y)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ for AC1200 (801.11ac) Wireless Dual-Band USB Adapter
 
 This code is base on version 4.3.14 from https://github.com/diederikdehaas/rtl8812AU
 
+### Update for NVidia Jestson Nano support
+
+This code was forked from https://github.com/abperiasamy/rtl8812AU_8821AU_linux
+
 ## Known Supported Devices:
 
 ```
@@ -17,6 +21,12 @@ This code is base on version 4.3.14 from https://github.com/diederikdehaas/rtl88
 
 ```sh
 # sudo make -f Makefile.dkms install
+```
+
+### Compiling for NVidia Jeston Nano
+
+```sh
+# CONFIG_PLATFORM_ARM_JET_NANO = y
 ```
 
 ### Compiling for Raspberry Pi


### PR DESCRIPTION
This is my first time updating a Linux kernel module. So please review and provide feedback.
This changes are minimal and following the instructions for RPI the module builds and installs.
I am having issues with eth0 and wlan0/1 conflicting. I can get wlan0/1 to connect to a essid and obtain an IP. This seems to work well when wlan0/1 are set to dhcp but when static there's an issue. There's a real good chance that I might be doing something wrong at that point.

At the end of the day, this project does build for Jetson Nano, installs the ko file and works as excepted.
Thanks,
Jason