### PR TITLE
Add support for Archer T2U Nano 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This code was forked from https://github.com/abperiasamy/rtl8812AU_8821AU_linux
 ```
 * COMFAST 1200Mbps USB Wireless Adapter(Model: CF-912AC)
 * TP-LINK AC1200 Wireless Dual Band USB Adapter(Model: Archer-T4U)
+* TP-LINK AC600 Wireless Dual Band USB Adapter(Model: Archer-T2U Nano)
 ```
 
 ## Compiling with DKMS

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -332,6 +332,8 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x056E, 0x400E),.driver_info = RTL8821}, /* ELECOM - WDC-433SU2M2 */
 	{USB_DEVICE(0x0BDA, 0xA811),.driver_info = RTL8821}, /* Comfast - CF-915AC, CF-916AC */
 	{USB_DEVICE(0x3823, 0x6249),.driver_info = RTL8821}, /* Obihai - OBiWiFi */
+	{USB_DEVICE(0x2357, 0x011E),.driver_info = RTL8821}, /* TP-Link - Archer T2U Nano */
+
 #endif
 
 #ifdef CONFIG_RTL8192E


### PR DESCRIPTION
* Add support for [Archer T2U Nano](https://www.amazon.com/TP-Link-Mini-Wireless-Supports-10-9-10-14/dp/B07PB1X4CN) - tested on Nvidia Jetson Nano