### PR TITLE
Refactor case-statement to if-statement to avoid implicit fallthrough.

### DIFF
--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -672,6 +672,8 @@ static void _mgt_dispatcher(_adapter *padapter, struct mlme_handler *ptable, uni
 
 void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 {
+	int subtype;
+
 	int index;
 	struct mlme_handler *ptable;
 #ifdef CONFIG_AP_MODE
@@ -751,50 +753,61 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 #endif
 
 #ifdef CONFIG_AP_MODE
-	switch (GetFrameSubType(pframe)) {
-	case WIFI_AUTH:
+	subtype = GetFrameSubType(pframe);
+	if ((subtype == WIFI_AUTH) ||
+	    (subtype == WIFI_ASSOCREQ) ||
+	    (subtype == WIFI_REASSOCREQ))
+	{
 		if(check_fwstate(pmlmepriv, WIFI_AP_STATE) == _TRUE)
+		{
 			ptable->func = &OnAuth;
+		}
 		else
+		{
 			ptable->func = &OnAuthClient;
-	//pass through
-	case WIFI_ASSOCREQ:
-	case WIFI_REASSOCREQ:
-		_mgt_dispatcher(padapter, ptable, precv_frame);
-#ifdef CONFIG_HOSTAPD_MLME
-		if(check_fwstate(pmlmepriv, WIFI_AP_STATE) == _TRUE)
-			rtw_hostapd_mlme_rx(padapter, precv_frame);
-#endif
-		break;
-	case WIFI_PROBEREQ:
-		if(check_fwstate(pmlmepriv, WIFI_AP_STATE) == _TRUE) {
-#ifdef CONFIG_HOSTAPD_MLME
-			rtw_hostapd_mlme_rx(padapter, precv_frame);
-#else
+		}
+
+		// fallthrough
+		if ((subtype == WIFI_ASSOCREQ) ||
+		    (subtype == WIFI_REASSOCREQ))
+		{
 			_mgt_dispatcher(padapter, ptable, precv_frame);
-#endif
-		} else
+
+			if(check_fwstate(pmlmepriv, WIFI_AP_STATE) == _TRUE)
+			{
+				rtw_hostapd_mlme_rx(padapter, precv_frame);
+			}
+		}
+	}
+	else if (subtype == WIFI_PROBEREQ)
+	{
+		if (check_fwstate(pmlmepriv, WIFI_AP_STATE) == _TRUE) {
+			#ifdef CONFIG_HOSTAPD_MLME
+				rtw_hostapd_mlme_rx(padapter, precv_frame);
+			#else
+				_mgt_dispatcher(padapter, ptable, precv_frame);
+			#endif
+		}
+		else
+		{
 			_mgt_dispatcher(padapter, ptable, precv_frame);
-		break;
-	case WIFI_BEACON:
+		}
+	} else if (subtype == WIFI_BEACON ||
+	           subtype == WIFI_ACTION)
+	{
 		_mgt_dispatcher(padapter, ptable, precv_frame);
-		break;
-	case WIFI_ACTION:
-		//if(check_fwstate(pmlmepriv, WIFI_AP_STATE) == _TRUE)
-		_mgt_dispatcher(padapter, ptable, precv_frame);
-		break;
-	default:
+	}
+	else
+	{
 		_mgt_dispatcher(padapter, ptable, precv_frame);
 		if(check_fwstate(pmlmepriv, WIFI_AP_STATE) == _TRUE)
+		{
 			rtw_hostapd_mlme_rx(padapter, precv_frame);
-		break;
+		}
 	}
 #else
-
 	_mgt_dispatcher(padapter, ptable, precv_frame);
-
 #endif
-
 }
 
 #ifdef CONFIG_P2P


### PR DESCRIPTION
When attempting to compile master gcc complains:
```
In function ‘mgt_dispatcher’:
core/rtw_mlme_ext.c:756:5: error: this statement may fall through [-Werror=implicit-fallthrough=]
```

Refactoring the case-statement to an if-statement allows it to compile without any errors.