### PR TITLE
Make driver work with kernel 5.3.6-200 as used by Fedora 30

### DIFF
--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -758,7 +758,9 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 		else
 			ptable->func = &OnAuthClient;
 	//pass through
+	//fallthrough
 	case WIFI_ASSOCREQ:
+	//fallthrough
 	case WIFI_REASSOCREQ:
 		_mgt_dispatcher(padapter, ptable, precv_frame);
 #ifdef CONFIG_HOSTAPD_MLME

--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -1173,6 +1173,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = BRCM_VENDOR_SCMD_PRIV_STR
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_priv_string_handler
 	},
 #if defined(GSCAN_SUPPORT) && 0
@@ -1182,6 +1185,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_GET_CAPABILITIES
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_gscan_get_capabilities
 	},
 	{
@@ -1190,6 +1196,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_SET_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_set_scan_cfg
 	},
 	{
@@ -1198,6 +1207,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_SET_SCAN_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_set_batch_scan_cfg
 	},
 	{
@@ -1206,6 +1218,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_ENABLE_GSCAN
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_initiate_gscan
 	},
 	{
@@ -1214,6 +1229,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_ENABLE_FULL_SCAN_RESULTS
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_enable_full_scan_result
 	},
 	{
@@ -1222,6 +1240,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_SET_HOTLIST
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_hotlist_cfg
 	},
 	{
@@ -1230,6 +1251,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_SET_SIGNIFICANT_CHANGE_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_significant_change_cfg
 	},
 	{
@@ -1238,6 +1262,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_GET_SCAN_RESULTS
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_gscan_get_batch_results
 	},
 	{
@@ -1246,6 +1273,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_GET_CHANNEL_LIST
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_gscan_get_channel_list
 	},
 #endif /* GSCAN_SUPPORT */
@@ -1256,6 +1286,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = RTT_SUBCMD_SET_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_rtt_set_config
 	},
 	{
@@ -1264,6 +1297,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = RTT_SUBCMD_CANCEL_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_rtt_cancel_config
 	},
 	{
@@ -1272,6 +1308,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = RTT_SUBCMD_GETCAPABILITY
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_rtt_get_capability
 	},
 #endif /* RTT_SUPPORT */
@@ -1281,6 +1320,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = ANDR_WIFI_SUBCMD_GET_FEATURE_SET
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = rtw_cfgvendor_get_feature_set
 	},
 	{
@@ -1289,6 +1331,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = ANDR_WIFI_SUBCMD_GET_FEATURE_SET_MATRIX
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = rtw_cfgvendor_get_feature_set_matrix
 	}
 };


### PR DESCRIPTION
Note that this is a patch intended for 4235b0ec7d7220a6364586d8e25b1e8cb99c36f1

The HEAD state (fa68771376a637c0b5f9cfa53da008570939a259) fails to authenticate.

There are two patches included:
* One to make suitable implicit-fallthrough comments for kernel 5.3 (apparently this changed?)
* One to extend the partial .policy changes already made earlier (got the hint from aircrack-ng/rtl8812au#421 as the dmesg failures were the same)