### PR TITLE
Fixes for use with kernel 5.8.x

### DIFF
--- a/core/rtw_security.c
+++ b/core/rtw_security.c
@@ -2200,7 +2200,7 @@ BIP_exit:
 
 #ifndef PLATFORM_FREEBSD
 /* compress 512-bits */
-static int sha256_compress(struct sha256_state *md, unsigned char *buf)
+static int sha256_compress(struct rtl_sha256_state *md, unsigned char *buf)
 {
 	u32 S[8], W[64], t0, t1;
 	u32 t;
@@ -2249,7 +2249,7 @@ static int sha256_compress(struct sha256_state *md, unsigned char *buf)
 }
 
 /* Initialize the hash state */
-static void sha256_init(struct sha256_state *md)
+static void sha256_init(struct rtl_sha256_state *md)
 {
 	md->curlen = 0;
 	md->length = 0;
@@ -2270,7 +2270,7 @@ static void sha256_init(struct sha256_state *md)
    @param inlen  The length of the data (octets)
    @return CRYPT_OK if successful
 */
-static int sha256_process(struct sha256_state *md, unsigned char *in,
+static int sha256_process(struct rtl_sha256_state *md, unsigned char *in,
                           unsigned long inlen)
 {
 	unsigned long n;
@@ -2311,7 +2311,7 @@ static int sha256_process(struct sha256_state *md, unsigned char *in,
    @param out [out] The destination of the hash (32 bytes)
    @return CRYPT_OK if successful
 */
-static int sha256_done(struct sha256_state *md, unsigned char *out)
+static int sha256_done(struct rtl_sha256_state *md, unsigned char *out)
 {
 	int i;
 
@@ -2363,7 +2363,7 @@ static int sha256_done(struct sha256_state *md, unsigned char *out)
 static int sha256_vector(size_t num_elem, u8 *addr[], size_t *len,
                          u8 *mac)
 {
-	struct sha256_state ctx;
+	struct rtl_sha256_state ctx;
 	size_t i;
 
 	sha256_init(&ctx);

--- a/include/rtw_security.h
+++ b/include/rtw_security.h
@@ -233,7 +233,7 @@ struct security_priv {
 #endif /* DBG_SW_SEC_CNT */
 };
 
-struct sha256_state {
+struct rtl_sha256_state {
 	u64 length;
 	u32 state[8], curlen;
 	u8 buf[64];

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -5177,7 +5177,41 @@ exit:
 	return ret;
 }
 
-static void cfg80211_rtw_mgmt_frame_register(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0))
+
+static void cfg80211_rtw_update_mgmt_frame_register(struct wiphy *wiphy,
+        struct wireless_dev *wdev,
+        struct mgmt_frame_regs *upd)
+{
+	u32 rtw_mask = BIT(IEEE80211_STYPE_PROBE_REQ >> 4);
+	struct net_device *ndev = wdev_to_ndev(wdev);
+	struct rtw_wdev_priv *wd;
+	_adapter *adapter;
+
+	if (ndev == NULL)
+		goto exit;
+
+	adapter = (_adapter *)rtw_netdev_priv(ndev);
+	wd = adapter_wdev_data(adapter);
+
+#ifdef CONFIG_DEBUG_CFG80211
+	DBG_871X(FUNC_ADPT_FMT" frame_type:%x, reg:%d\n", FUNC_ADPT_ARG(adapter),
+	         frame_type, reg);
+	DBG_871X(FUNC_ADPT_FMT " old_regs:%x new_regs:%x\n",
+			FUNC_ADPT_ARG(adapter), wd->mgmt_mask, upd->interface_stypes);
+#endif
+
+	if ((upd->interface_stypes & rtw_mask) == (wd->mgmt_mask & rtw_mask))
+		return;
+	wd->mgmt_mask = upd->interface_stypes;
+exit:
+	return;
+
+}
+
+#else
+
+static inline void cfg80211_rtw_mgmt_frame_register(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0))
         struct wireless_dev *wdev,
 #else
@@ -5205,6 +5239,8 @@ static void cfg80211_rtw_mgmt_frame_register(struct wiphy *wiphy,
 exit:
 	return;
 }
+
+#endif
 
 #if defined(CONFIG_TDLS) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3,2,0))
 static int cfg80211_rtw_tdls_mgmt(struct wiphy *wiphy,
@@ -6019,7 +6055,10 @@ static struct cfg80211_ops rtw_cfg80211_ops = {
 	.cancel_remain_on_channel = cfg80211_rtw_cancel_remain_on_channel,
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)) || defined(COMPAT_KERNEL_RELEASE)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0))
+    .mgmt_tx = cfg80211_rtw_mgmt_tx,
+    .update_mgmt_frame_registrations = cfg80211_rtw_update_mgmt_frame_register,
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)) || defined(COMPAT_KERNEL_RELEASE)
 	.mgmt_tx = cfg80211_rtw_mgmt_tx,
 	.mgmt_frame_register = cfg80211_rtw_mgmt_frame_register,
 #elif  (LINUX_VERSION_CODE>=KERNEL_VERSION(2,6,34) && LINUX_VERSION_CODE<=KERNEL_VERSION(2,6,35))

--- a/os_dep/linux/ioctl_cfg80211.h
+++ b/os_dep/linux/ioctl_cfg80211.h
@@ -104,6 +104,7 @@ struct rtw_wdev_priv {
 	ATOMIC_T switch_ch_to;
 #endif
 
+    u32 mgmt_mask;
 };
 
 #define wiphy_to_adapter(x) (*((_adapter**)wiphy_priv(x)))


### PR DESCRIPTION
I wasn't aware of https://github.com/abperiasamy/rtl8812AU_8821AU_linux/pull/337 when i started, but this fix for sha256_state might be more simple.
Also needs https://github.com/abperiasamy/rtl8812AU_8821AU_linux/pull/333 https://github.com/abperiasamy/rtl8812AU_8821AU_linux/pull/316 5.3 5.6 patches for working with 5.8.x kernel