### PR TITLE
remove uneeded & broken set_fs()/get_fs() for kernel 5.10+

### DIFF
--- a/core/efuse/rtw_efuse.c
+++ b/core/efuse/rtw_efuse.c
@@ -1448,7 +1448,9 @@ void Rtw_Hal_ReadMACAddrFromFile(PADAPTER padapter)
 {
 	u32 i;
 	struct file *fp;
+#ifndef RTW_NO_SET_FS
 	mm_segment_t fs;
+#endif
 	u8 source_addr[18];
 	loff_t pos = 0;
 	u32 curtime = rtw_get_current_time();
@@ -1466,8 +1468,10 @@ void Rtw_Hal_ReadMACAddrFromFile(PADAPTER padapter)
 		pEEPROM->bloadmac_fail_flag = _TRUE;
 		DBG_871X("Error, wifi mac address file doesn't exist.\n");
 	} else {
+#ifndef RTW_NO_SET_FS
 		fs = get_fs();
 		set_fs(KERNEL_DS);
+#endif
 
 		DBG_871X("wifi mac address:\n");
 		vfs_read(fp, source_addr, 18, &pos);
@@ -1490,7 +1494,9 @@ void Rtw_Hal_ReadMACAddrFromFile(PADAPTER padapter)
 			DBG_871X("%02x \n", pEEPROM->mac_addr[i]);
 		}
 		DBG_871X("\n");
+#ifndef RTW_NO_SET_FS
 		set_fs(fs);
+#endif
 		pEEPROM->bloadmac_fail_flag = _FALSE;
 		filp_close(fp, NULL);
 	}
@@ -1516,7 +1522,9 @@ u32 Rtw_Hal_readPGDataFromConfigFile(PADAPTER	padapter)
 {
 	u32 i;
 	struct file *fp;
+#ifndef RTW_NO_SET_FS
 	mm_segment_t fs;
+#endif
 	u8 temp[3];
 	loff_t pos = 0;
 	EEPROM_EFUSE_PRIV *pEEPROM = GET_EEPROM_EFUSE_PRIV(padapter);
@@ -1532,8 +1540,10 @@ u32 Rtw_Hal_readPGDataFromConfigFile(PADAPTER	padapter)
 		return _FAIL;
 	}
 
+#ifndef RTW_NO_SET_FS
 	fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 
 	DBG_871X("Efuse configure file:\n");
 	for (i=0; i< EFUSE_MAP_SIZE  ; i++) {
@@ -1543,7 +1553,9 @@ u32 Rtw_Hal_readPGDataFromConfigFile(PADAPTER	padapter)
 		DBG_871X("%02X \n", PROMContent[i]);
 	}
 	DBG_871X("\n");
+#ifndef RTW_NO_SET_FS
 	set_fs(fs);
+#endif
 
 	filp_close(fp, NULL);
 

--- a/core/rtw_btcoex.c
+++ b/core/rtw_btcoex.c
@@ -1415,7 +1415,9 @@ u8 rtw_btcoex_sendmsgbysocket(_adapter *padapter, u8 *msg, u8 msg_size)
 {
 	u8 error;
 	struct msghdr	udpmsg;
+#ifndef RTW_NO_SET_FS
 	mm_segment_t	oldfs;
+#endif
 	struct iovec	iov;
 	struct bt_coex_info *pcoex_info = &padapter->coex_info;
 
@@ -1432,11 +1434,15 @@ u8 rtw_btcoex_sendmsgbysocket(_adapter *padapter, u8 *msg, u8 msg_size)
 		udpmsg.msg_control	= NULL;
 		udpmsg.msg_controllen = 0;
 		udpmsg.msg_flags	= MSG_DONTWAIT | MSG_NOSIGNAL;
+#ifndef RTW_NO_SET_FS
 		oldfs = get_fs();
 		set_fs(KERNEL_DS);
+#endif
 		error = sock_sendmsg(pcoex_info->udpsock, &udpmsg, msg_size);
 		//rtw_msleep_os(20);
+#ifndef RTW_NO_SET_FS
 		set_fs(oldfs);
+#endif
 		if(error < 0) {
 			DBG_871X("Error when sendimg msg, error:%d\n",error);
 			return _FAIL;

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -3831,7 +3831,9 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t* ssid,
 
 	int i = 0;
 	struct file *fp;
+#ifndef RTW_NO_SET_FS
 	mm_segment_t fs;
+#endif
 	loff_t pos = 0;
 	u8 *source = NULL;
 	long len = 0;
@@ -3868,8 +3870,10 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t* ssid,
 		return 0;
 	}
 
+#ifndef RTW_NO_SET_FS
 	fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 
 	source = rtw_zmalloc(2048);
 
@@ -3879,7 +3883,9 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t* ssid,
 		rtw_mfree(source, 2048);
 	}
 
+#ifndef RTW_NO_SET_FS
 	set_fs(fs);
+#endif
 	filp_close(fp, NULL);
 
 	DBG_871X("-%s-\n", __func__);

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -6069,7 +6069,9 @@ u32 Hal_readPGDataFromConfigFile(
     struct file *fp)
 {
 	u32 i;
+#ifndef RTW_NO_SET_FS
 	mm_segment_t fs;
+#endif
 	u8 temp[3];
 	loff_t pos = 0;
 	EEPROM_EFUSE_PRIV *pEEPROM = GET_EEPROM_EFUSE_PRIV(padapter);
@@ -6077,8 +6079,10 @@ u32 Hal_readPGDataFromConfigFile(
 
 	temp[2] = 0; // add end of string '\0'
 
+#ifndef RTW_NO_SET_FS
 	fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 
 	for (i = 0 ; i < HWSET_MAX_SIZE ; i++) {
 		vfs_read(fp, temp, 2, &pos);
@@ -6095,7 +6099,9 @@ u32 Hal_readPGDataFromConfigFile(
 		}
 	}
 
+#ifndef RTW_NO_SET_FS
 	set_fs(fs);
+#endif
 	pEEPROM->bloadfile_fail_flag = _FALSE;
 
 #ifdef CONFIG_DEBUG
@@ -6117,7 +6123,9 @@ void Hal_ReadMACAddrFromFile(
     struct file *fp)
 {
 	u32 i;
+#ifndef RTW_NO_SET_FS
 	mm_segment_t fs;
+#endif
 	u8 source_addr[18];
 	loff_t pos = 0;
 	u32	curtime = rtw_get_current_time();
@@ -6127,8 +6135,10 @@ void Hal_ReadMACAddrFromFile(
 	_rtw_memset(source_addr, 0, 18);
 	_rtw_memset(pEEPROM->mac_addr, 0, ETH_ALEN);
 
+#ifndef RTW_NO_SET_FS
 	fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 
 	DBG_871X("wifi mac address:\n");
 	vfs_read(fp, source_addr, 18, &pos);
@@ -6150,7 +6160,9 @@ void Hal_ReadMACAddrFromFile(
 		}
 	}
 
+#ifndef RTW_NO_SET_FS
 	set_fs(fs);
+#endif
 	pEEPROM->bloadmac_fail_flag = _FALSE;
 
 	if (rtw_check_invalid_mac_address(pEEPROM->mac_addr) == _TRUE) {

--- a/hal/rtl8812a/rtl8812a_hal_init.c
+++ b/hal/rtl8812a/rtl8812a_hal_init.c
@@ -3325,7 +3325,9 @@ static s32 _halReadPGDataFromFile(PADAPTER padapter, u8 *pbuf)
 {
 	u32 i;
 	struct file *fp;
+#ifndef RTW_NO_SET_FS
 	mm_segment_t fs;
+#endif
 	u8 temp[3];
 	loff_t pos = 0;
 	EEPROM_EFUSE_PRIV *pEEPROM = GET_EEPROM_EFUSE_PRIV(padapter);
@@ -3341,14 +3343,18 @@ static s32 _halReadPGDataFromFile(PADAPTER padapter, u8 *pbuf)
 		return _FAIL;
 	}
 
+#ifndef RTW_NO_SET_FS
 	fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 	for (i=0; i<HWSET_MAX_SIZE_JAGUAR; i++) {
 		vfs_read(fp, temp, 2, &pos);
 		pbuf[i] = simple_strtoul(temp, NULL, 16);
 		pos += 1; // Filter the space character
 	}
+#ifndef RTW_NO_SET_FS
 	set_fs(fs);
+#endif
 	filp_close(fp, NULL);
 
 #ifdef CONFIG_DEBUG
@@ -3370,7 +3376,9 @@ static s32 _halReadPGDataFromFile(PADAPTER padapter, u8 *pbuf)
 static s32 _halReadMACAddrFromFile(PADAPTER padapter, u8 *pbuf)
 {
 	struct file *fp;
+#ifndef RTW_NO_SET_FS
 	mm_segment_t fs;
+#endif
 	loff_t pos = 0;
 	u8 source_addr[18];
 	u8 *head, *end;
@@ -3392,8 +3400,10 @@ static s32 _halReadMACAddrFromFile(PADAPTER padapter, u8 *pbuf)
 		ret = _FAIL;
 		DBG_8192C("%s: Error, Read MAC address file FAIL!\n", __FUNCTION__);
 	} else {
+#ifndef RTW_NO_SET_FS
 		fs = get_fs();
 		set_fs(KERNEL_DS);
+#endif
 
 		vfs_read(fp, source_addr, 18, &pos);
 		source_addr[17] = ':';
@@ -3413,7 +3423,9 @@ static s32 _halReadMACAddrFromFile(PADAPTER padapter, u8 *pbuf)
 				head = end;
 			}
 		}
+#ifndef RTW_NO_SET_FS
 		set_fs(fs);
+#endif
 		filp_close(fp, NULL);
 
 		DBG_8192C("%s: Read MAC address from file [%s]\n", __FUNCTION__, WIFIMAC_PATH);

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -127,6 +127,14 @@ typedef struct urb *  PURB;
 #endif
 #endif
 
+/* set_fs(KERNEL_DS) uneeded and removed above 5.10 */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0))
+	#define RTW_NO_SET_FS
+/* This is to fix get_ds() type mismatch on kernels above 5.1.x */
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
+	#define get_ds() KERNEL_DS
+#endif
+
 typedef struct 	semaphore _sema;
 typedef	spinlock_t	_lock;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37))

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -2756,7 +2756,9 @@ static int route_dump(u32 *gw_addr ,int* gw_index)
 	struct msghdr msg;
 	struct iovec iov;
 	struct sockaddr_nl nladdr;
+#ifndef RTW_NO_SET_FS
 	mm_segment_t oldfs;
+#endif
 	char *pg;
 	int size = 0;
 
@@ -2792,14 +2794,18 @@ static int route_dump(u32 *gw_addr ,int* gw_index)
 	msg.msg_controllen = 0;
 	msg.msg_flags = MSG_DONTWAIT;
 
+#ifndef RTW_NO_SET_FS
 	oldfs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
 	err = sock_sendmsg(sock, &msg, sizeof(req));
 #else
 	err = sock_sendmsg(sock, &msg);
 #endif
+#ifndef RTW_NO_SET_FS
 	set_fs(oldfs);
+#endif
 
 	if (size < 0)
 		goto out_sock;
@@ -2820,11 +2826,15 @@ restart:
 		iov.iov_base = pg;
 		iov.iov_len = PAGE_SIZE;
 
+#ifndef RTW_NO_SET_FS
 		oldfs = get_fs();
 		set_fs(KERNEL_DS);
+#endif
 		//err = sock_recvmsg(sock, &msg, PAGE_SIZE, MSG_DONTWAIT);
 		err = sock_recvmsg(sock, &msg, MSG_DONTWAIT);
+#ifndef RTW_NO_SET_FS
 		set_fs(oldfs);
+#endif
 
 		if (err < 0)
 			goto out_sock_pg;
@@ -2898,14 +2908,18 @@ done:
 		msg.msg_controllen = 0;
 		msg.msg_flags=MSG_DONTWAIT;
 
+#ifndef RTW_NO_SET_FS
 		oldfs = get_fs();
 		set_fs(KERNEL_DS);
+#endif
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
 		err = sock_sendmsg(sock, &msg, sizeof(req));
 #else
 		err = sock_sendmsg(sock, &msg);
 #endif
+#ifndef RTW_NO_SET_FS
 		set_fs(oldfs);
+#endif
 
 		if (err > 0)
 			goto restart;


### PR DESCRIPTION
using set_fs() and get_fs() to access the memory is long uneeded and finally removed in linux kernel 5.10 +, this PR fixes build against 5.10+ by cease this behavior with a macro, `RTW_NO_SET_FS`. By default it is only enabled for 5.10+, but I recommend to define that any time as this `set_fs(KERNEL_DS)` usage may cause severe security holes in some way.